### PR TITLE
Multiple answer scoring fix

### DIFF
--- a/parse.php
+++ b/parse.php
@@ -368,7 +368,6 @@ function make_quiz($submit, $questions, $errors, $seed=-1) {
                 $expected = $answer[0];  // An actual boolean
                 $oneanswer = $oneanswer || isset($submit[$a_code]);
                 $ans->checked = isset($submit[$a_code]);
-                // $actual = isset($submit[$a_code]) ? ($submit[$a_code] == 'true') === $expected : false;
 
                 $actual = false;
                 if (isset($submit[$a_code])) {  // If the user checked the box for this answer...

--- a/parse.php
+++ b/parse.php
@@ -371,19 +371,17 @@ function make_quiz($submit, $questions, $errors, $seed=-1) {
                 // $actual = isset($submit[$a_code]) ? ($submit[$a_code] == 'true') === $expected : false;
 
                 $actual = false;
-                if (isset($submit[$a_code])) {
-                  if ($submit[$a_code] == 'true') {
-                    if ($expected){
-                      $actual = true;
-                    }
+                if (isset($submit[$a_code])) {  // If the user checked the box for this answer...
+                  if ($expected){               // And the answer was supposed to be checked
+                    $actual = true;             // Then the user should get a point towards the score
                   }
-                } else {
-                  if (!$expected){
-                    $actual = true;
+                } else {                        // If the user did NOT check this box...
+                  if (!$expected){              // And the answer was not supposed to be checked
+                    $actual = true;             // Then the user should get a point
                   }
                 }
 
-                if ( $actual ) $got++;
+                if ( $actual ) $got++;          // $actual is true if the user gave the correct option
                 $need++;
                 $ans->code = $a_code;
                 if ( $doscore ) {

--- a/parse.php
+++ b/parse.php
@@ -368,8 +368,22 @@ function make_quiz($submit, $questions, $errors, $seed=-1) {
                 $expected = $answer[0];  // An actual boolean
                 $oneanswer = $oneanswer || isset($submit[$a_code]);
                 $ans->checked = isset($submit[$a_code]);
-                $actual = isset($submit[$a_code]) ? ($submit[$a_code] == 'true') === $expected : false;
-                if ( $actual === $expected ) $got++;
+                // $actual = isset($submit[$a_code]) ? ($submit[$a_code] == 'true') === $expected : false;
+
+                $actual = false;
+                if (isset($submit[$a_code])) {
+                  if ($submit[$a_code] == 'true') {
+                    if ($expected){
+                      $actual = true;
+                    }
+                  }
+                } else {
+                  if (!$expected){
+                    $actual = true;
+                  }
+                }
+
+                if ( $actual ) $got++;
                 $need++;
                 $ans->code = $a_code;
                 if ( $doscore ) {


### PR DESCRIPTION
For multiple choice questions, this bit: (lines 371-3)

```
$actual = isset($submit[$a_code]) ? ($submit[$a_code] == 'true') === $expected : false;
if ( $actual === $expected ) $got++;
$need++;
```

works as long as $expected is true. ($submit[$a_code] == 'true') is true, and $expected is true, so $actual === $expected and $got increases. If isset($submit[$a_code])==false and $expected is true, $actual != $expected and $got does not increase. 

However, if the answer is supposed to be false and the provided answer is true (i.e. the user selected an option that was incorrect), the user should not receive a point.  In that case, ($submit[$a_code] == 'true') is true, and $expected is false, so $actual is set to false. But in the next line $actual === $expected so $got still increases regardless. 

This can be verified by creating a multiple choice question with more than one Correct answer and at least one incorrect answer:

```
::Q1 MA:: Three of these are right and five are wrong 
{ =Right =Correct =Not Wrong ~Incorrect ~Falsch ~Not Close ~Incorrecto ~Felaktig}
```

Missing a single answer which should be marked results in a score of 0 for the question:
![ex1](https://user-images.githubusercontent.com/35118448/35954228-7ef2f3b2-0c56-11e8-9dd0-d3789517c000.PNG)
But selecting multiple incorrect answers does not penalize the user as long as the correct answers are selected as well:
![ex2](https://user-images.githubusercontent.com/35118448/35954230-841ca356-0c56-11e8-8c0b-720cbd99a957.PNG)
